### PR TITLE
Upgrade kotest from 4.3.2 to 4.4.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,7 +17,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 
-version.kotest=4.3.2
+version.kotest=4.4.0
 
 version.kotlin=1.4.21
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.