### PR TITLE
Upgrade commons-lang3 from 3.11 to 3.12.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,6 +23,6 @@ version.kotlin=1.4.31
 
 version.orchid=0.21.1
 
-version.org.apache.commons..commons-lang3=3.11
+version.org.apache.commons..commons-lang3=3.12.0
 
 version.org.danilopianini..khttp=0.1.0-dev0w+9990241


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.